### PR TITLE
modify allowed origins list

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -18,18 +18,14 @@ app = FastAPI(title="Ballroom Medellin API")
 
 ENV = os.getenv("ENV", "development")
 
-ALLOWED_ORIGINS = (
-    [
-        "https://www.ballroomedellin.com",
-        "https://development.ballroomedellin.com",
-    ]
-    if ENV == "production"
-    else [
-        "http://localhost",
-        "http://localhost:5173",
-        "https://localhost",
-    ]
-)
+ALLOWED_ORIGINS = [
+    "https://www.ballroomedellin.com",
+    "https://development.ballroomedellin.com",
+    "http://localhost",
+    "http://localhost:5173",
+    "https://localhost:5173",
+    "https://localhost",
+]
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
add localhost to fix youtube list not showing

## Summary by Sourcery

Bug Fixes:
- Fix YouTube list not showing on localhost by allowing requests from localhost:5173 and https://localhost:5173.