### PR TITLE
Merge Develop into main

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -17,7 +17,12 @@ if not YOUTUBE_API_KEY or not YOUTUBE_CHANNEL_ID:
         "Missing required environment variables: YOUTUBE_API_KEY or YOUTUBE_CHANNEL_ID"
     )
 
-app = FastAPI(title="Ballroom Medellin API")
+app = FastAPI(
+    title="Ballroom Medellin API",
+    docs_url="/docs",
+    redoc_url="/redoc",
+    openapi_url="/openapi.json"
+)
 
 ENV = os.getenv("ENV", "development")
 
@@ -49,6 +54,7 @@ async def youtube_info():
         )
 
     return {"channel_id": YOUTUBE_CHANNEL_ID}
+
 
 @app.get("/calendar-events")
 async def calendar_events(db: AsyncSession = Depends(get_db)):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,16 +15,14 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: bm-services_container
-    restart: unless-stopped
     image: bm-services
-    expose:
-      - "8000"
+    restart: unless-stopped
     env_file:
       - .env
+    expose:
+      - "8000"
     networks:
       - app_network
-    ports:
-      - "8080:8000"
 
   nginx:
     image: nginx:latest
@@ -34,8 +32,8 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
-      - /etc/letsencrypt:/etc/letsencrypt:ro
+      - ./nginx/conf.d/default.conf:/etc/nginx/conf.d/default.conf:ro
+      - /home/queen/certs:/etc/nginx/certs:ro
     depends_on:
       - fastapi
     networks:

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -1,0 +1,28 @@
+server {
+    listen 443 ssl;
+    server_name ballroom.local;
+
+    ssl_certificate     /etc/nginx/certs/ballroom.local.crt;
+    ssl_certificate_key /etc/nginx/certs/ballroom.local.key;
+
+    resolver 127.0.0.11 valid=30s;
+
+    add_header Content-Security-Policy
+        "default-src 'self';
+        script-src 'self' http://www.youtube.com http://www.youtube-nocookie.com https://cdn.jsdelivr.net 'sha256-QOOQu4W1oxGqd2nbXbxiA1Di6OHQOLQD+o+G9oWL8YY=';
+        frame-src  'self' http://www.youtube.com http://www.youtube-nocookie.com;
+        style-src  'self' 'unsafe-inline' https://cdn.jsdelivr.net;
+        img-src    'self' data: https://i.ytimg.com https://fastapi.tiangolo.com;
+        connect-src 'self' https://ballroom.local;" always;
+
+    location / {
+        proxy_pass http://fastapi:8000/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,34 +1,11 @@
-server {
-    listen 80;
-    server_name api.ballroomedellin.com;
+events {}
 
-    return 301 https://$host$request_uri;
-    
-    location / {
-        proxy_pass http://fastapi:8080;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-}
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
 
-server {
-    listen 443 ssl;
-    server_name api.ballroomedellin.com;
+    sendfile        on;
+    keepalive_timeout  65;
 
-    ssl_certificate /etc/letsencrypt/live/ballroomedellin.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/ballroomedellin.com/privkey.pem;
-
-    ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_ciphers 'TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-CHACHA20-POLY1305:HIGH:!aNULL:!MD5';
-    ssl_prefer_server_ciphers on;
-
-    location / {
-        proxy_pass http://fastapi:8000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
+    include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
## Summary by Sourcery

Refactor and externalize Nginx configuration into a dedicated conf.d file, update Docker Compose mounts and service definitions, and enable custom FastAPI documentation endpoints.

New Features:
- Add Content-Security-Policy header in the Nginx reverse proxy configuration
- Expose custom FastAPI documentation and OpenAPI endpoints via docs_url, redoc_url, and openapi_url settings

Enhancements:
- Restructure nginx.conf to use generic events/http blocks and delegate server details to nginx/conf.d/default.conf
- Update docker-compose.yml to mount the new Nginx conf and certificate paths, adjust expose directives, and streamline restart policies